### PR TITLE
Add the option of customizing the certificate verification method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+### 0.22.2 (2020-01-25)
+
+* Allow customizable Root CA verification function
+
 ### 0.22.1 (2020-01-13)
 
 * Fix SAML token auth using Holder-of-Key with delegated Bearer identity against 6.7 U3b+

--- a/vim25/soap/client.go
+++ b/vim25/soap/client.go
@@ -159,6 +159,13 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	return &c
 }
 
+type CertVerifyFunc func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+
+func (c *Client) SetCertVerificationMethod(verifyMethod CertVerifyFunc) {
+  c.t.TLSClientConfig.InsecureSkipVerify = true
+  c.t.TLSClientConfig.VerifyPeerCertificate = verifyMethod
+}
+
 // NewServiceClient creates a NewClient with the given URL.Path and namespace.
 func (c *Client) NewServiceClient(path string, namespace string) *Client {
 	vc := c.URL()


### PR DESCRIPTION
Some users request a slightly less secure verification that the normal TLS method

This could include, for example, verifying everything normally except for matching the hostname.

This allows the user to specify their own verification method (which they are then liable for)